### PR TITLE
fix for ppc

### DIFF
--- a/csnappy_internal_userspace.h
+++ b/csnappy_internal_userspace.h
@@ -90,43 +90,6 @@ typedef unsigned __int64 uint64_t;
 # error __LITTLE_ENDIAN or __BIG_ENDIAN must be defined, not both!
 #endif
 
-/* Convert to little-endian storage, opposite of network format. */
-#if defined(__BIG_ENDIAN)
-
-/* The following guarantees declaration of the byte swap functions. */
-#ifdef _MSC_VER
-#include <stdlib.h>
-#define bswap_16(x) _byteswap_ushort(x)
-#define bswap_32(x) _byteswap_ulong(x)
-#define bswap_64(x) _byteswap_uint64(x)
-#elif defined(__APPLE__)
-/* Mac OS X / Darwin features */
-#include <libkern/OSByteOrder.h>
-#define bswap_16(x) OSSwapInt16(x)
-#define bswap_32(x) OSSwapInt32(x)
-#define bswap_64(x) OSSwapInt64(x)
-#else
-#include <byteswap.h>
-#endif
-
-static inline uint32_t get_unaligned_le32(const void *p)
-{
-	return bswap_32(UNALIGNED_LOAD32(p));
-}
-
-static inline void put_unaligned_le16(uint16_t val, void *p)
-{
-	uint8_t *pp = (uint8_t*)p;
-	*pp++ = val;
-	*pp++ = val >> 8;
-}
-
-#else /* !defined(__BIG_ENDIAN) */
-#define get_unaligned_le32(p)		(*(const uint32_t*)(p))
-#define put_unaligned_le16(v, p)	*(uint16_t*)(p) = (uint16_t)(v)
-#endif /* !defined(__BIG_ENDIAN) */
-
-
 /* Potentially unaligned loads and stores. */
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__)
@@ -182,6 +145,42 @@ static inline void UNALIGNED_STORE64(void *p, uint64_t v)
 
 #endif /* !(x86 || powerpc) */
 
+
+/* Convert to little-endian storage, opposite of network format. */
+#if defined(__BIG_ENDIAN)
+
+/* The following guarantees declaration of the byte swap functions. */
+#ifdef _MSC_VER
+#include <stdlib.h>
+#define bswap_16(x) _byteswap_ushort(x)
+#define bswap_32(x) _byteswap_ulong(x)
+#define bswap_64(x) _byteswap_uint64(x)
+#elif defined(__APPLE__)
+/* Mac OS X / Darwin features */
+#include <libkern/OSByteOrder.h>
+#define bswap_16(x) OSSwapInt16(x)
+#define bswap_32(x) OSSwapInt32(x)
+#define bswap_64(x) OSSwapInt64(x)
+#else
+#include <byteswap.h>
+#endif
+
+static inline uint32_t get_unaligned_le32(const void *p)
+{
+	return bswap_32(UNALIGNED_LOAD32(p));
+}
+
+static inline void put_unaligned_le16(uint16_t val, void *p)
+{
+	uint8_t *pp = (uint8_t*)p;
+	*pp++ = val;
+	*pp++ = val >> 8;
+}
+
+#else /* !defined(__BIG_ENDIAN) */
+#define get_unaligned_le32(p)		(*(const uint32_t*)(p))
+#define put_unaligned_le16(v, p)	*(uint16_t*)(p) = (uint16_t)(v)
+#endif /* !defined(__BIG_ENDIAN) */
 
 #if defined(HAVE_BUILTIN_CTZ)
 


### PR DESCRIPTION
reordered some code so functions where defined before called. tested the fix indirectly using cpan testers:

before: http://www.cpantesters.org/cpan/report/1463de16-6e70-11e0-8cde-750ced0326e0
after: http://www.cpantesters.org/cpan/report/9e2a018a-71fd-11e0-9abf-e615ed0326e0
