### PR TITLE
Don't use loop initial declarations for gnu89

### DIFF
--- a/csnappy_decompress.c
+++ b/csnappy_decompress.c
@@ -88,10 +88,11 @@ int csnappy_decompress_noheader(
 		if (likely((opcode & 3) == 0)) {
 			if (unlikely(length > 60)) {
 				uint32_t extra_bytes = length - 60;
+				int shift;
 				if (unlikely(src + extra_bytes > src_end))
 					return CSNAPPY_E_DATA_MALFORMED;
 				length = 0;
-				for (int shift = 0, max_shift = extra_bytes*8;
+				for (shift = 0, max_shift = extra_bytes*8;
 					shift < max_shift;
 					shift += 8)
 					length |= *src++ << shift;


### PR DESCRIPTION
reference error: http://www.cpantesters.org/cpan/report/46d05a6a-6dba-11e1-bf5e-0355147e4811
