### PR TITLE
Cygwin uses glibc but undefs __GLIBC__

### DIFF
--- a/csnappy_internal_userspace.h
+++ b/csnappy_internal_userspace.h
@@ -83,7 +83,7 @@ Albert Lee
 #define bswap_32(x) _byteswap_ulong(x)
 #define bswap_64(x) _byteswap_uint64(x)
 
-#elif defined(__GLIBC__) || defined(__ANDROID__)
+#elif defined(__GLIBC__) || defined(__ANDROID__) || defined(__CYGWIN__)
 
 #include <endian.h>
 #include <byteswap.h>


### PR DESCRIPTION
reference error: http://www.cpantesters.org/cpan/report/39d16900-6df9-11e1-96dd-c9df8433098a
