### PR TITLE
endian.h, clang and FreeBSD

### DIFF
--- a/csnappy_internal_userspace.h
+++ b/csnappy_internal_userspace.h
@@ -117,11 +117,6 @@ Albert Lee
 #define __LITTLE_ENDIAN	1234
 #define __BYTE_ORDER	LITTLE_ENDIAN
 
-#elif defined(__GNUC__) || defined(__ANDROID__) || defined(__CYGWIN__)
-
-#include <endian.h>
-#include <byteswap.h>
-
 #elif defined(__APPLE__)
 
 #include <machine/endian.h>
@@ -152,6 +147,11 @@ Albert Lee
 #define __BYTE_ORDER _BYTE_ORDER
 #define __LITTLE_ENDIAN _LITTLE_ENDIAN
 #define __BIG_ENDIAN _BIG_ENDIAN
+
+#elif defined(__GNUC__) || defined(__ANDROID__) || defined(__CYGWIN__)
+
+#include <endian.h>
+#include <byteswap.h>
 
 #elif defined(__sun)
 


### PR DESCRIPTION
Hi,

To be honest I'm not sure that this's a proper fix. So, I'm open for suggestions.

Commit c9a463ae79e5181ebb42951713686ebba7f2d48d led to subtle issue on
FreeBSD where clangs defined __GNUC__ macros.

$ echo | clang -dM -E - | grep -i gnu
    #define __GNUC_MINOR__ 2
    #define __GNUC_PATCHLEVEL__ 1
    #define __GNUC_STDC_INLINE__ 1
    #define __GNUC__ 4

This cause csnappy_internal_userspace.h to include endian.h using wrong
path. Relevant piece of code:

    ...
    #elif defined(__GNUC__) || defined(__ANDROID__) || defined(__CYGWIN__)

    #include <endian.h>
    #include <byteswap.h>

    #elif defined(__FreeBSD__) || defined(__DragonFly__) || defined(__NetBSD__)

    #include <sys/endian.h>

    #elif defined(__OpenBSD__)
    ...

So, defined(__GNUC__) comes before defined(__FreeBSD__)

More information about clang and __GNUC__:
    - http://stackoverflow.com/questions/1617877/how-to-detect-llvm-and-its-version-through-define-directives
    - http://rem.eifzilla.de/archives/2012/08/10/identify-theft-by-clang