### PR TITLE
endian.h and mingw (same as PR #27)

### DIFF
--- a/csnappy_internal_userspace.h
+++ b/csnappy_internal_userspace.h
@@ -148,6 +148,12 @@ Albert Lee
 #define __LITTLE_ENDIAN _LITTLE_ENDIAN
 #define __BIG_ENDIAN _BIG_ENDIAN
 
+#elif defined(__MINGW32__)
+#include <sys/param.h>
+#define __BYTE_ORDER BYTE_ORDER
+#define __LITTLE_ENDIAN LITTLE_ENDIAN
+#define __BIG_ENDIAN BIG_ENDIAN
+
 #elif defined(__GNUC__) || defined(__ANDROID__) || defined(__CYGWIN__)
 
 #include <endian.h>
@@ -166,12 +172,6 @@ Albert Lee
 #else
 #define __BYTE_ORDER __BIG_ENDIAN
 #endif
-
-#elif defined(__MINGW32__)
-#include <sys/param.h>
-#define __BYTE_ORDER BYTE_ORDER
-#define __LITTLE_ENDIAN LITTLE_ENDIAN
-#define __BIG_ENDIAN BIG_ENDIAN
 
 #elif defined(__hpux)
 


### PR DESCRIPTION
csnappy failed to compile on mingw (win32) with following error:

In file included from snappy/csnappy_internal.h:45:0,
                 from snappy/csnappy_decompress.c:38,
                 from srl_decoder.c:52:
snappy/csnappy_internal_userspace.h:153:20: fatal error: endian.h: No such file or directory
 #include <endian.h>

It's the same problem as reported in PR #27. The fix is similar as well.
I just moved __MINGW32__ to be before __GNUC__.