### PR TITLE
fix gcc 6.3.0 warnings by removing useless cast

### DIFF
--- a/csnappy_decompress.c
+++ b/csnappy_decompress.c
@@ -271,7 +271,7 @@ SAW__AppendFastPath(struct SnappyArrayWriter *this,
 		UnalignedCopy64(ip, op);
 		UnalignedCopy64(ip + 8, op + 8);
 	} else {
-                if (unlikely(space_left < (int32_t)len))
+                if (unlikely(space_left < len))
 			return CSNAPPY_E_OUTPUT_OVERRUN;
 		memcpy(op, ip, len);
 	}
@@ -285,7 +285,7 @@ SAW__Append(struct SnappyArrayWriter *this,
 {
 	char *op = this->op;
 	const uint32_t space_left = this->op_limit - op;
-        if (unlikely(space_left < (int32_t)len))
+        if (unlikely(space_left < len))
 		return CSNAPPY_E_OUTPUT_OVERRUN;
 	memcpy(op, ip, len);
 	this->op = op + len;
@@ -305,10 +305,10 @@ SAW__AppendFromSelf(struct SnappyArrayWriter *this,
 	if (len <= 16 && offset >= 8 && space_left >= 16) {
 		UnalignedCopy64(op - offset, op);
 		UnalignedCopy64(op - offset + 8, op + 8);
-        } else if (space_left >= (int32_t)(len + kMaxIncrementCopyOverflow)) {
+        } else if (space_left >= (len + kMaxIncrementCopyOverflow)) {
 		IncrementalCopyFastPath(op - offset, op, len);
 	} else {
-                if (space_left < (int32_t)len)
+                if (space_left < len)
 			return CSNAPPY_E_OUTPUT_OVERRUN;
 		IncrementalCopy(op - offset, op, len);
 	}


### PR DESCRIPTION
`space_left` and `len` are both `uint32_t`.

```
csnappy/csnappy_decompress.c: In function 'SAW__AppendFastPath':
csnappy/csnappy_decompress.c:274:41: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
                 if (unlikely(space_left < (int32_t)len))
                                         ^
csnappy/csnappy_internal_userspace.h:92:41: note: in definition of macro 'unlikely'
 #define unlikely(x) __builtin_expect(!!(x), 0)
                                         ^
csnappy/csnappy_decompress.c: In function 'SAW__Append':
csnappy/csnappy_decompress.c:288:33: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         if (unlikely(space_left < (int32_t)len))
                                 ^
csnappy/csnappy_internal_userspace.h:92:41: note: in definition of macro 'unlikely'
 #define unlikely(x) __builtin_expect(!!(x), 0)
                                         ^
In file included from lsnappy.c:9:0:
csnappy/csnappy_decompress.c: In function 'SAW__AppendFromSelf':
csnappy/csnappy_decompress.c:308:31: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
         } else if (space_left >= (int32_t)(len + kMaxIncrementCopyOverflow)) {
                               ^~
csnappy/csnappy_decompress.c:311:32: warning: comparison between signed and unsigned integer expressions [-Wsign-compare]
                 if (space_left < (int32_t)len)
                                ^
```