### PR TITLE
fix gcc 8.2.0 warnings

### DIFF
--- a/csnappy_compress.c
+++ b/csnappy_compress.c
@@ -86,7 +86,7 @@ encode_varint32(char *sptr, uint32_t v)
 #define kBlockSize (1 << kBlockLog)
 
 
-#if defined(__arm__) && !(ARCH_ARM_HAVE_UNALIGNED)
+#if defined(__arm__) && !defined(ARCH_ARM_HAVE_UNALIGNED)
 
 static uint8_t* emit_literal(
 	uint8_t *op,

--- a/csnappy_decompress.c
+++ b/csnappy_decompress.c
@@ -73,7 +73,7 @@ err_out:
 EXPORT_SYMBOL(csnappy_get_uncompressed_length);
 #endif
 
-#if defined(__arm__) && !(ARCH_ARM_HAVE_UNALIGNED)
+#if defined(__arm__) && !defined(ARCH_ARM_HAVE_UNALIGNED)
 int csnappy_decompress_noheader(
 	const char	*src_,
 	uint32_t	src_remaining,

--- a/csnappy_internal.h
+++ b/csnappy_internal.h
@@ -86,12 +86,14 @@ Steffen Mueller <smueller@cpan.org>
 #  error either __LITTLE_ENDIAN or __BIG_ENDIAN, plus __BYTE_ORDER must be defined
 #endif
 
-#define ARCH_ARM_HAVE_UNALIGNED \
-    defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) || defined(__ARMV6__) || \
+#if defined(__ARM_ARCH_6__) || defined(__ARM_ARCH_6J__) || defined(__ARM_ARCH_6K__) || defined(__ARM_ARCH_6Z__) || defined(__ARM_ARCH_6ZK__) || defined(__ARM_ARCH_6T2__) || defined(__ARMV6__) || \
     defined(__ARM_ARCH_7__) || defined(__ARM_ARCH_7A__) || defined(__ARM_ARCH_7R__) || defined(__ARM_ARCH_7M__)
+#  define ARCH_ARM_HAVE_UNALIGNED
+#endif
+
 
 static INLINE void UnalignedCopy64(const void *src, void *dst) {
-#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || ARCH_ARM_HAVE_UNALIGNED
+#if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || defined(ARCH_ARM_HAVE_UNALIGNED)
   if ((sizeof(void *) == 8) || (sizeof(long) == 8)) {
     UNALIGNED_STORE64(dst, UNALIGNED_LOAD64(src));
   } else {
@@ -118,7 +120,7 @@ static INLINE void UnalignedCopy64(const void *src, void *dst) {
 }
 
 #if defined(__arm__)
-  #if ARCH_ARM_HAVE_UNALIGNED
+  #if defined(ARCH_ARM_HAVE_UNALIGNED)
      static INLINE uint32_t get_unaligned_le(const void *p, uint32_t n)
      {
        uint32_t wordmask = (1U << (8 * n)) - 1;


### PR DESCRIPTION
the #define of ARCH_ARM_HAVE_UNALIGNED was unusual

```
cc -std=gnu89 -Wall -pedantic -DHAVE_BUILTIN_CTZ -g -O2 -DNDEBUG -fomit-frame-pointer -fPIC -DPIC -c -o csnappy_compress.o csnappy_compress.c
In file included from csnappy_compress.c:38:
csnappy_internal.h: In function 'UnalignedCopy64':
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
 #if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || ARCH_ARM_HAVE_UNALIGNED
                                                                         ^~~~~~~~~~~~~~~~~~~~~~~
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c: At top level:
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
 #if defined(__arm__) && !(ARCH_ARM_HAVE_UNALIGNED)
                           ^~~~~~~~~~~~~~~~~~~~~~~
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_compress.c:89:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
cc -std=gnu89 -Wall -pedantic -DHAVE_BUILTIN_CTZ -g -O2 -DNDEBUG -fomit-frame-pointer -fPIC -DPIC -c -o csnappy_decompress.o csnappy_decompress.c
In file included from csnappy_decompress.c:38:
csnappy_internal.h: In function 'UnalignedCopy64':
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
 #if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__) || ARCH_ARM_HAVE_UNALIGNED
                                                                         ^~~~~~~~~~~~~~~~~~~~~~~
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_internal.h:94:73: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c: At top level:
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
 #if defined(__arm__) && !(ARCH_ARM_HAVE_UNALIGNED)
                           ^~~~~~~~~~~~~~~~~~~~~~~
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
csnappy_decompress.c:76:27: warning: this use of "defined" may not be portable [-Wexpansion-to-defined]
```