### PR TITLE
Possible fix for issue #10 - optimization issue with gcc 10

### DIFF
--- a/csnappy_internal_userspace.h
+++ b/csnappy_internal_userspace.h
@@ -251,14 +251,23 @@ Albert Lee
 /* Potentially unaligned loads and stores. */
 
 #if defined(__i386__) || defined(__x86_64__) || defined(__powerpc__)
+#if defined(__GNUC__)
+typedef uint16_t my_uint16_t __attribute__((aligned(1)));
+typedef uint32_t my_uint32_t __attribute__((aligned(1)));
+typedef uint64_t my_uint64_t __attribute__((aligned(1)));
+#else
+typedef uint16_t my_uint16_t;
+typedef uint32_t my_uint32_t;
+typedef uint64_t my_uint64_t;
+#endif
 
-#define UNALIGNED_LOAD16(_p) (*(const uint16_t*)(_p))
-#define UNALIGNED_LOAD32(_p) (*(const uint32_t*)(_p))
-#define UNALIGNED_LOAD64(_p) (*(const uint64_t*)(_p))
+#define UNALIGNED_LOAD16(_p) (*(const my_uint16_t*)(_p))
+#define UNALIGNED_LOAD32(_p) (*(const my_uint32_t*)(_p))
+#define UNALIGNED_LOAD64(_p) (*(const my_uint64_t*)(_p))
 
-#define UNALIGNED_STORE16(_p, _val) (*(uint16_t*)(_p) = (_val))
-#define UNALIGNED_STORE32(_p, _val) (*(uint32_t*)(_p) = (_val))
-#define UNALIGNED_STORE64(_p, _val) (*(uint64_t*)(_p) = (_val))
+#define UNALIGNED_STORE16(_p, _val) (*(my_uint16_t*)(_p) = (_val))
+#define UNALIGNED_STORE32(_p, _val) (*(my_uint32_t*)(_p) = (_val))
+#define UNALIGNED_STORE64(_p, _val) (*(my_uint64_t*)(_p) = (_val))
 
 #elif defined(__arm__) && \
 	!defined(__ARM_ARCH_4__) && \


### PR DESCRIPTION
Unaligned access causing optimization issues with -O3 due to undefined behavior.

See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=96326